### PR TITLE
feat: restructure animals_etl, separate API wrappers from http_client, and optimize fetch id concurrency

### DIFF
--- a/src/animals_etl/__init__.py
+++ b/src/animals_etl/__init__.py
@@ -1,7 +1,7 @@
 __all__ = [
     "config",
     "cli",
-    "http_client",
+    "api",
     "models",
     "pipeline",
     "utils",

--- a/src/animals_etl/api.py
+++ b/src/animals_etl/api.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import sys
+from typing import Any, Dict
+
+from http_client import HttpClient
+
+from .models import AnimalRaw, AnimalDetail, AnimalsBatch
+
+class AnimalsAPI:
+    def __init__(self, http: HttpClient):
+        self.http = http
+
+    async def list_animals(self, page: int) -> AnimalRaw:
+        resp = await self.http.request("GET", "/animals/v1/animals", params={"page": page})
+        try:
+            return resp.json()
+        except ValueError:
+            print(f"[warn] Non-JSON for page {page}", file=sys.stderr)
+            return {"items": [], "total_pages": 1, "page": page}
+
+    async def get_animal(self, animal_id: int) -> AnimalDetail:
+        resp = await self.http.request("GET", f"/animals/v1/animals/{animal_id}")
+        try:
+            return resp.json()
+        except ValueError:
+            print(f"[warn] non-JSON response for id {animal_id}: {resp.text[:200]}", file=sys.stderr)
+            return {}
+
+    async def post_home(self, batch: AnimalsBatch) -> Dict[str, Any]:
+        resp = await self.http.request("POST", "/animals/v1/home", json=batch)
+        try:
+            return resp.json()
+        except ValueError:
+            return {}

--- a/src/animals_etl/cli.py
+++ b/src/animals_etl/cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import asyncio, sys
 
-from http_client import HttpClient
+from http_client import HttpClient, ValidationHTTPError
 
 from .api import AnimalsAPI
 from .config import parse_args
@@ -33,5 +33,8 @@ def main() -> None:
     args = parse_args()
     try:
         asyncio.run(run(args))
+    except ValidationHTTPError as e:
+        print(f"Validation error: {e.detail}", file=sys.stderr)
+        sys.exit(2)
     except KeyboardInterrupt:
         print("Aborted.", file=sys.stderr)

--- a/src/animals_etl/cli.py
+++ b/src/animals_etl/cli.py
@@ -1,20 +1,37 @@
 from __future__ import annotations
 import asyncio, sys
+
+from http_client import HttpClient
+
+from .api import AnimalsAPI
 from .config import parse_args
-from .pipeline import run_etl
+from .pipeline import fetch_all_ids, fetch_details_concurrent, transform_records, post_batches
+
+async def run(args):
+    async with HttpClient(
+        base_url=args.base_url,
+        connect_timeout=args.connect_timeout,
+        read_timeout=args.read_timeout,
+        retries=args.retries,
+    ) as http:
+        api = AnimalsAPI(http)
+        print(f"""
+            ====== Animals ETL (async) ======
+            Base URL       : {args.base_url}
+            Concurrency    : {args.concurrency}
+            Batch size     : {args.batch_size}
+            Retries        : {args.retries}
+            Timeouts (s)   : connect={args.connect_timeout} read={args.read_timeout}
+            ===============================
+        """)
+        ids = await fetch_all_ids(api, min(3, max(1, args.concurrency // 2)))
+        details = await fetch_details_concurrent(api, ids, args.concurrency)
+        transformed = transform_records(details)
+        await post_batches(api, transformed, args.batch_size)
 
 def main() -> None:
     args = parse_args()
     try:
-        asyncio.run(
-            run_etl(
-                base_url=args.base_url,
-                concurrency=args.concurrency,
-                batch_size=args.batch_size,
-                retries=args.retries,
-                connect_timeout=args.connect_timeout,
-                read_timeout=args.read_timeout,
-            )
-        )
+        asyncio.run(run(args))
     except KeyboardInterrupt:
         print("Aborted.", file=sys.stderr)

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -132,10 +132,10 @@ class HttpClient:
                 params = kwargs.get("params")
                 has_json = kwargs.get("json") is not None
                 err_kind = f"HTTP {getattr(getattr(last_exc, 'response', None), 'status_code', 'ERR')}" \
-                           if isinstance(last_exc, httpx.HTTPStatusError) else "network"
+                        if isinstance(last_exc, httpx.HTTPStatusError) else "network"
                 print(f"[req#{req_id}] [retry {attempt}/{self.policy.retries}] {method} {url} "
-                      f"params={params} json={has_json} failed: {err_kind}: {last_exc}. "
-                      f"Sleeping {sleep:.2f}s", file=sys.stderr)
+                    f"params={params} json={has_json} failed: {err_kind}: {last_exc}. "
+                    f"Sleeping {sleep:.2f}s", file=sys.stderr)
                 await asyncio.sleep(sleep)
             else:
                 print(f"[req#{req_id}] [giving up] {method} {url}: {last_exc}", file=sys.stderr)

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -1,16 +1,45 @@
+# animals_etl/http_client.py
 from __future__ import annotations
-import uuid, sys, asyncio, random
-from typing import Any, Dict, List, Optional
+import sys, asyncio, random, uuid
+from typing import Optional
 import httpx
-from .utils import RETRY_STATUSES
 
-from .models import AnimalRaw, AnimalDetail, AnimalsBatch
-class AsyncETL:
+class RetryPolicy:
+    def __init__(
+        self,
+        retries: int = 6,
+        backoff_base: float = 0.25,
+        backoff_cap: float = 4.0,
+        retry_statuses: set[int] | None = None,
+    ):
+        self.retries = max(1, retries)
+        self.backoff_base = backoff_base
+        self.backoff_cap = backoff_cap
+        self.retry_statuses = retry_statuses or {500, 502, 503, 504}
+
+    def sleep_seconds(self, attempt: int) -> float:
+        # exponential (0.5, 1, 2, 4, 8...) + jitter [0..0.5]
+        return min(self.backoff_cap, self.backoff_base * (2 ** (attempt - 1))) + random.uniform(0, 0.5)
+
+class HttpClient:
     """
-    Async HTTP client wrapper for the Animals API.
-    Handles retries, backoff, logging, and concurrency.
+    - Reusable async HTTP client with:
+      - base_url
+      - httpx timeouts
+      - retry policy (5xx + network)
+      - 4xx fail fast
     """
-    def __init__(self, base_url: str, connect_timeout: float, read_timeout: float, retries: int, concurrency: int):
+
+    def __init__(
+        self,
+        base_url: str,
+        connect_timeout: float,
+        read_timeout: float,
+        retries: int,
+        *,
+        retry_statuses: Optional[set[int]] = None,
+        default_headers: Optional[dict[str, str]] = None,
+    ):
         self.base_url = base_url.rstrip("/")
         self.timeout = httpx.Timeout(
             connect=connect_timeout,
@@ -18,47 +47,43 @@ class AsyncETL:
             write=read_timeout,
             pool=read_timeout,
         )
-        self.concurrency = max(1, min(32, concurrency))
-        self.retries = retries
-        self.sem = asyncio.Semaphore(self.concurrency)
-        self.client: Optional[httpx.AsyncClient] = None
+        self.policy = RetryPolicy(retries=retries, retry_statuses=retry_statuses)
+        self.default_headers = {"Accept": "application/json", **(default_headers or {})}
+        self._client: Optional[httpx.AsyncClient] = None
 
     async def __aenter__(self):
-        self.client = httpx.AsyncClient(
-            base_url=self.base_url,
-            timeout=self.timeout,
-            headers={"Accept": "application/json"},
-        )
+        self._client = httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout, headers=self.default_headers)
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
-        if self.client is not None:
-            await self.client.aclose()
+        if self._client is not None:
+            await self._client.aclose()
 
-    async def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
+    async def request(self, method: str, path: str, **kwargs) -> httpx.Response:
         """
         Generic request with retry logic.
         Retries transient 5xx + network errors; fails fast on 4xx. Special 422 handling.
         Each request tagged with X-Request-Id for traceability.
         """
-        assert self.client is not None
+        assert self._client is not None
         last_exc: Exception | None = None
+
         req_id = kwargs.pop("req_id", str(uuid.uuid4()))
         headers = kwargs.pop("headers", {})
         headers.setdefault("X-Request-Id", req_id)
         kwargs["headers"] = headers
-        
+
         url = self.base_url + path # for logs
 
-        for attempt in range(1, self.retries + 1):
+        for attempt in range(1, self.policy.retries + 1):
             try:
-                resp = await self.client.request(method, path, **kwargs)
+                resp = await self._client.request(method, path, **kwargs)
                 status = resp.status_code
-                
+
                 # Retry on transient 5xx
-                if status in RETRY_STATUSES:
+                if status in self.policy.retry_statuses:
                     raise httpx.HTTPStatusError(f"server error {status}", request=resp.request, response=resp)
-                
+
                 # 422 (validation) handling: log useful details, then fail fast
                 if status == 422:
                     try:
@@ -72,63 +97,39 @@ class AsyncETL:
                 # Fail fast, don’t retry
                 if 400 <= status < 500:
                     resp.raise_for_status()
-                
+
                 # Defensive: no other non-2xx should slip through
                 if not (200 <= status < 300):
-                    if 500 <= status < 600 and status not in RETRY_STATUSES:
+                    if 500 <= status < 600 and status not in self.policy.retry_statuses:
                         print(f"[req#{req_id}] [fatal] {method} {url} returned {status}, not retrying", file=sys.stderr)
                     resp.raise_for_status()
-                
+
                 if attempt > 1:
                     print(f"[req#{req_id}] succeeded after {attempt} attempt(s)", file=sys.stderr)
                 return resp
-            
+
             except httpx.HTTPStatusError as e:
-                 # If it's 4xx, do NOT retry
                 status = getattr(e.response, "status_code", None)
                 if status is not None and 400 <= status < 500:
                     print(f"[req#{req_id}] [fatal] {method} {url} returned {status}, not retrying", file=sys.stderr)
                     raise
                 last_exc = e
+
             except httpx.HTTPError as e:
                 last_exc = e
 
-            if attempt < self.retries:
-                sleep = min(8.0, 0.5 * (2 ** (attempt - 1))) + random.uniform(0, 0.5)
+            if attempt < self.policy.retries:
+                sleep = self.policy.sleep_seconds(attempt)
                 params = kwargs.get("params")
                 has_json = kwargs.get("json") is not None
                 err_kind = f"HTTP {getattr(getattr(last_exc, 'response', None), 'status_code', 'ERR')}" \
-                       if isinstance(last_exc, httpx.HTTPStatusError) else "network"
-                print(f"[req#{req_id}] [retry {attempt}/{self.retries}] {method} {url} "
-                    f"params={params} json={has_json} failed: {err_kind}: {last_exc}. "
-                    f"Sleeping {sleep:.2f}s", file=sys.stderr)
+                           if isinstance(last_exc, httpx.HTTPStatusError) else "network"
+                print(f"[req#{req_id}] [retry {attempt}/{self.policy.retries}] {method} {url} "
+                      f"params={params} json={has_json} failed: {err_kind}: {last_exc}. "
+                      f"Sleeping {sleep:.2f}s", file=sys.stderr)
                 await asyncio.sleep(sleep)
             else:
                 print(f"[req#{req_id}] [giving up] {method} {url}: {last_exc}", file=sys.stderr)
                 raise last_exc or RuntimeError("request failed")
 
         raise last_exc or RuntimeError("request failed")
-
-    # API wrappers
-    async def list_animals(self, page: int) -> AnimalRaw:
-        resp = await self._request("GET", "/animals/v1/animals", params={"page": page})
-        try:
-            return resp.json()
-        except ValueError:
-            print(f"[warn] Non-JSON for page {page}", file=sys.stderr)
-            return {"items": [], "total_pages": 1}
-
-    async def get_animal(self, animal_id: int) -> AnimalDetail:
-        resp = await self._request("GET", f"/animals/v1/animals/{animal_id}")
-        try:
-            return resp.json()
-        except ValueError:
-            print(f"[warn] non-JSON response for id {animal_id}: {resp.text[:200]}", file=sys.stderr)
-            return {}
-
-    async def post_home(self, animals: AnimalsBatch) -> Dict[str, Any]:
-        resp = await self._request("POST", "/animals/v1/home", json=animals)
-        try:
-            return resp.json()
-        except ValueError:
-            return {}


### PR DESCRIPTION
### Changes  
- Updated `fetch_all_ids` to use an `asyncio.Semaphore` for page fetching.  
- Page concurrency is now controlled via CLI argument (`--concurrency`).  
- Prevents unbounded parallel requests while still allowing parallel fetches.  
- Included the following new modules:  
  - `api.py` → API client wrapper around HTTP requests  
- Moved shared `HttpClient` to `src/http_client.py` (top-level utility)  

### Why
- Separates HTTP logic and API wrappers
- Avoids overwhelming the API with too many simultaneous requests.  
- Keeps behaviour consistent with `fetch_details_concurrent`, which already uses semaphores.  

### Notes
- All ETL logic now lives under `src/animals_etl/`  
- Next steps: add test coverage