### PR TITLE
chore: add Makefile and __main__.py entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+# ---- config ----
+PYTHON ?= python3
+VENV := .venv
+PIP := $(VENV)/bin/pip
+PY := $(VENV)/bin/python
+PYTEST := $(VENV)/bin/pytest
+
+.PHONY: help setup test run clean
+
+help:
+	@echo "Available targets:"
+	@echo "  make setup     - create virtualenv and install deps"
+	@echo "  make test      - run pytest"
+	@echo "  make run ARGS='--base-url http://localhost:3123 --concurrency=10...' - run the app"
+	@echo "  make clean     - remove venv and caches"
+
+setup:
+	@$(PYTHON) -m venv $(VENV)
+	@$(PIP) install --upgrade pip
+	@$(PIP) install -r requirements.txt
+	@$(PIP) install -e .
+
+test:
+	@$(PYTEST) -q
+
+run:
+	@$(VENV)/bin/animals-etl $(ARGS)
+
+clean:
+	@rm -rf $(VENV) .pytest_cache
+	@find . -type d -name "__pycache__" -exec rm -rf {} +
+	@find . -type f -name "*.pyc" -delete
+	@find . -type d -name "*.egg-info" -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Project-Fauna
 An ETL (Extract → Transform → Load) pipeline for the Animals API, built with Python 3.10+ 
 
-## Steps to run the pipeline
+
+## (Recommended) Steps to run the pipeline using make commands:
+1. Create virtual environment and install dependencies
+`make setup`
+2. Execute pipeline with optional arguments (use `make help` to understand how the commands work)
+`make run`
+3. Run tests
+`make test`
+4. Remove venv, cache and build artifacts
+`make clean`
+
+## Steps to run the pipeline using virtual environment
 1. Create and activate virtual environment
 python3 -m venv .venv
 source .venv/bin/activate
@@ -20,6 +31,9 @@ animals-etl
 
 5. To run tests
 pytest -q
+
+6. Exit virtual environment
+deactivate
 
 
 ## Steps to run the script

--- a/src/animals_etl/__main__.py
+++ b/src/animals_etl/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR improves developer experience by introducing a `Makefile` and an entrypoint (`__main__.py`) for running the app directly with `python -m animals_etl`.

### Changes
- Added `Makefile` with the following targets:
  - `make setup` → create venv & install dependencies
  - `make test` → run pytest inside venv
  - `make run` → execute `animals-etl` with optional arguments
  - `make clean` → remove venv, cache, and build artifacts
- Added `__main__.py` in `animals_etl` so the app can be executed via:
  ```bash
  python -m animals_etl --base-url http://localhost:3123